### PR TITLE
Create pki-validation test file

### DIFF
--- a/.well-known/pki-validation/random-file.txt
+++ b/.well-known/pki-validation/random-file.txt
@@ -1,0 +1,1 @@
+This file should not be routable on a *.github.io site


### PR DESCRIPTION
Since we already provide SSL certs for `*.github.io` sites, `pki-validation/*` should not be routable. Placing this file here so we can run e2e tests to ensure this is always the case.